### PR TITLE
Migrate to asserts syntax, fix fields access

### DIFF
--- a/contracts/event-split.clar
+++ b/contracts/event-split.clar
@@ -69,4 +69,4 @@
     ;; Mutations:
     ;; - transfer-stx from contract to tx-sender
     ;; - update nft.refunded-at
-    (ok true)) 
+    (ok true))

--- a/contracts/event-split.clar
+++ b/contracts/event-split.clar
@@ -31,14 +31,22 @@
 
 ;; close-event-fundraise
 (define-public (close-event-fundraise (event-id (buff 64)))
-    (let ((event (map-get? events ((event-id event-id)))))
-         (if (is-none event) (err "event does not exist")
-             (if (< block-height event.expires-at) (err "too soon")
-                 (if (> event.exercised-at (to-uint 0)) (err "already exercised")
-                     (if (< event.current-amount event.total-amount) (err "not enough money yet")
-                         (begin (as-contract (stx-transfer? event.current-amount tx-sender event.recipient))
-                                ((map-set events ((event-id event-id)) ((exercised-at block-height)))
-                                (ok true))))))))
+    (let ((event (unwrap! (map-get? events ((event-id event-id))) 
+                          (err "event does not exist"))))
+        (asserts! (< (get expires-at event) block-height) (err "too soon"))
+        (asserts! (> (get exercised-at event) u0) (err "already exercised"))
+        (asserts! (< (get current-amount event) (get total-amount event)) (err "not enough money yet"))
+        (unwrap! 
+            (stx-transfer? (get current-amount event) (as-contract tx-sender) (get recipient event))
+            (err "unable to transfer stx"))
+        (map-set events ((event-id event-id)) {
+            total-amount: (get total-amount event),
+            expires-at: (get expires-at event),
+            recipient: (get recipient event),
+            exercised-at: block-height,
+            current-amount: u0
+        })
+        (ok true)))
 
 ;; buy-event-pass
 (define-public (buy-event-pass (event-id uint) (amount uint)) 
@@ -61,4 +69,4 @@
     ;; Mutations:
     ;; - transfer-stx from contract to tx-sender
     ;; - update nft.refunded-at
-    (ok true))
+    (ok true)) 


### PR DESCRIPTION
This PR is re-formulating the checks using assertions, so we avoid the current pyramid of `if`.
It also fixes the way fields were being accessed - the `.` syntax is not available, I'll let you open an issue on the stacks-blockchain repo if this is an improvement you'd like to support :).
I saw that you used the explicit tuple syntax, I'm showing an example of an alternative sugared syntax (`{ key: value }` notation) - I'll let you pick the one you prefer.

Note: native functions returning algebraic values (optionals returning none/some, and responses returning err/ok) are suffixed with a `?`. When using theses, you should be unwrapping the result, and take adequate actions.
Ex: if `stx-transfer?` fails, you should halt the execution and be returning an error, instead of keep mutating the state.

I noticed that the vscode extension is failing localizing and underlining parsing issues (ex: number of `)` does not match the number of `(`), and instead, underline the very first character - will look into this.

![Screenshot from 2020-05-26 11-26-13](https://user-images.githubusercontent.com/87777/82919217-bbc38680-9f43-11ea-8268-8afd970cba24.png)
 

